### PR TITLE
Make base margin apply to all edges of the panel

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -298,7 +298,7 @@ export default class DynamicPanelExtension extends Extension {
         if (floating) {
             const align = this._settings.get_int("float-align");
             const baseMargin = this._settings.get_int("base-margin");
-            const floating_width = screenWidth * (this._settings.get_int("float-width") / 100);
+            const floating_width = (screenWidth * (this._settings.get_int("float-width") / 100)) - (baseMargin * 2);
             let x = 0;
             switch (align) {
                 case 0:


### PR DESCRIPTION
This fixes the issue where the panel can overflow off the edge of the screen in certain cases. See #4 for details. :)

Basically, it applies the base margin to each side of the panel by multiplying it by two, then subtracting that from the `floating_width` variable that sets the panel's width.

| Extension Settings | My Desktop (using this pull request) | My Desktop (using the current extension codebase) |
| --------------------------- | ----------------- | ----------------- |
| ![image](https://github.com/user-attachments/assets/fb5f78a0-a1f0-46a9-98d7-fd342138d27c) | ![image](https://github.com/user-attachments/assets/93592db8-74ec-4d9e-9ff0-6f8e9d3ca399) | ![image](https://github.com/user-attachments/assets/54c7f1db-ca44-4ca9-a853-86fa72800db6) |